### PR TITLE
Configure dependency install policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAge: 10080
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary
- Set pnpm minimumReleaseAge to 10080 minutes (7 days)
- Enable pnpm blockExoticSubdeps

## Verification
- pnpm config get minimumReleaseAge -> 10080
- pnpm config get blockExoticSubdeps -> true